### PR TITLE
Update pubspec.yaml for latest fl_location

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  fl_location: ^1.2.2
+  fl_location: ^2.0.0+1
   flutter_foreground_task: ^3.8.2
   flutter_activity_recognition: ^1.3.0
 


### PR DESCRIPTION
Error when adding geofence_service. 

`\fl_location-1.2.2\android\src\main\kotlin\com\pravera\fl_location\service\LocationDataProvider.kt: (137, 23): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Location?`  etc

resolved by upgrading to the latest version of fl_location